### PR TITLE
Fix endpoint URL for transfer creation  Updated createTransfer method from /transfer to /transfers to resolve the "POST method not supported" error.

### DIFF
--- a/src/Chapa.php
+++ b/src/Chapa.php
@@ -86,7 +86,7 @@ class Chapa
     public function createTransfer(array $data)
     {
         $transfer = Http::withToken($this->secretKey)->post(
-            $this->baseUrl . '/transfer',
+            $this->baseUrl . '/transfers',
             $data
         )->json();
 


### PR DESCRIPTION
Fix: Update Endpoint URL for Transfer Creation
Changed the endpoint URL in the createTransfer method from /transfer to /transfers. The previous endpoint resulted in a "POST method not supported" error.  This update ensures that the API request is directed to the correct endpoint and allows successful transfer creation.