### PR TITLE
Expands the Chapa Laravel Package to include refund support and account balance queries.

### DIFF
--- a/.github/workflows/workflow_laravel.yml
+++ b/.github/workflows/workflow_laravel.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
-        php-version: '8.0'
+        php-version: '8.3'
     - uses: actions/checkout@v3
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"

--- a/src/Chapa.php
+++ b/src/Chapa.php
@@ -167,4 +167,39 @@ class Chapa
         return $response;
     }
 
+    /**
+     * Initiate a refund for a given transaction reference.
+     *
+     * @param  string  $txRef  Chapa transaction reference 
+     * @param  array   $data   Optional body: reason, amount, meta, reference
+     * @return array
+     */
+    public function refund(string $txRef, array $data = []): array
+    {
+        $response = Http::withToken($this->secretKey)->post(
+            $this->baseUrl . '/refund/' . $txRef,
+            $data
+        )->json();
+
+        return $response;
+    }
+    
+    /**
+     * Get your Chapa account balance.
+     *
+     * @param  string|null  $currency Optional currency code 
+     * @return array
+     */
+    public function getBalance(string $currency = null): array
+    {
+        $url = $this->baseUrl . '/balances';
+
+        if ($currency) {
+            $url .= '/' . strtolower($currency);
+        }
+
+        return Http::withToken($this->secretKey)
+            ->get($url)
+            ->json();
+    }
 }


### PR DESCRIPTION
This pull request introduces two new API wrapper methods to the Chapa Laravel SDK:

Added Features

1. refund() – Allows merchants to initiate a refund for a given transaction reference (tx_ref).
Accepts optional parameters such as reason, amount, meta, and reference.
Integrates with Chapa’s /v1/refund/{tx_ref} endpoint.

2. getBalance() – Enables retrieval of the merchant’s account balance.
Supports optional currency filtering (ETB, USD, etc.).
Connects to Chapa’s /v1/balances or /v1/balances/{currency} endpoints.

Technical Notes
Both methods utilize Laravel’s Http::withToken() for secure requests.
Fully consistent with existing service design and naming conventions.

Testing

Verified locally in test mode using sandbox keys.
Confirmed responses for valid and invalid tx_ref values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds refund and balance retrieval methods to the Chapa SDK and updates CI to PHP 8.3.
> 
> - **SDK (`src/Chapa.php`)**:
>   - Add `refund(string $txRef, array $data = [])` to POST `'/refund/{tx_ref}'`.
>   - Add `getBalance(string $currency = null)` to GET `'/balances'` or `'/balances/{currency}'`.
> - **CI (`.github/workflows/workflow_laravel.yml`)**:
>   - Update GitHub Actions PHP version to `8.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03cc30d9a544302f7e131060efef00ba36d7fc14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->