### PR TITLE
 Expands the Chapa Laravel Package to include refund support and account balance queries and update CI to PHP 8.3

### DIFF
--- a/.github/workflows/workflow_laravel.yml
+++ b/.github/workflows/workflow_laravel.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
-        php-version: '8.0'
+        php-version: '8.3'
     - uses: actions/checkout@v3
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"

--- a/src/Chapa.php
+++ b/src/Chapa.php
@@ -167,4 +167,39 @@ class Chapa
         return $response;
     }
 
+    /**
+     * Initiate a refund for a given transaction reference.
+     *
+     * @param  string  $txRef  Chapa transaction reference 
+     * @param  array   $data   Optional body: reason, amount, meta, reference
+     * @return array
+     */
+    public function refund(string $txRef, array $data = []): array
+    {
+        $response = Http::withToken($this->secretKey)->post(
+            $this->baseUrl . '/refund/' . $txRef,
+            $data
+        )->json();
+
+        return $response;
+    }
+    
+    /**
+     * Get your Chapa account balance.
+     *
+     * @param  string|null  $currency Optional currency code 
+     * @return array
+     */
+    public function getBalance(string $currency = null): array
+    {
+        $url = $this->baseUrl . '/balances';
+
+        if ($currency) {
+            $url .= '/' . strtolower($currency);
+        }
+
+        return Http::withToken($this->secretKey)
+            ->get($url)
+            ->json();
+    }
 }


### PR DESCRIPTION
This PR adds new API capabilities to the Chapa Laravel package and updates the CI workflow to ensure compatibility with current development dependencies.

New  Methods

**refund()**
Provides the ability to initiate refunds for a given tx_ref.
Supports optional fields such as reason, amount, reference, and meta.
Integrates with the /v1/refund/{tx_ref} endpoint using Http::withToken().

**getBalance()**
Retrieves the merchant’s account balance.
Accepts an optional currency parameter (ETB, USD, etc.).
Connects to /v1/balances or /v1/balances/{currency} depending on the request.

**CI Workflow Update**

Updated GitHub Actions to run tests on PHP 8.3, which is required by
PHPUnit 11 and Testbench 9.

Resolves Composer dependency conflicts previously occurring with PHP 8.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `refund` and `getBalance` methods to `src/Chapa.php` and updates GitHub Actions to run on PHP 8.3.
> 
> - **SDK (`src/Chapa.php`)**:
>   - Add `refund(string $txRef, array $data = [])` to initiate refunds via `POST /refund/{txRef}`.
>   - Add `getBalance(?string $currency = null)` to fetch balances via `GET /balances[/{currency}]`.
> - **CI**:
>   - Update GitHub Actions workflow to use PHP `8.3` in `.github/workflows/workflow_laravel.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03cc30d9a544302f7e131060efef00ba36d7fc14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->