### PR TITLE
feat: add refund & balance APIs and fix CI workflow for package testing

### DIFF
--- a/.github/workflows/workflow_laravel.yml
+++ b/.github/workflows/workflow_laravel.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
-        php-version: '8.0'
+        php-version: '8.3'
     - uses: actions/checkout@v3
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"

--- a/.github/workflows/workflow_laravel.yml
+++ b/.github/workflows/workflow_laravel.yml
@@ -15,21 +15,11 @@ jobs:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
         php-version: '8.3'
+
     - uses: actions/checkout@v3
-    - name: Copy .env
-      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
     - name: Install Dependencies
       run: composer update -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-    - name: Generate key
-      run: php artisan key:generate
-    - name: Directory Permissions
-      run: chmod -R 777 storage bootstrap/cache
-    - name: Create Database
-      run: |
-        mkdir -p database
-        touch database/database.sqlite
+
     - name: Execute tests (Unit and Feature tests) via PHPUnit
-      env:
-        DB_CONNECTION: sqlite
-        DB_DATABASE: database/database.sqlite
       run: vendor/bin/phpunit

--- a/src/Chapa.php
+++ b/src/Chapa.php
@@ -167,4 +167,39 @@ class Chapa
         return $response;
     }
 
+    /**
+     * Initiate a refund for a given transaction reference.
+     *
+     * @param  string  $txRef  Chapa transaction reference 
+     * @param  array   $data   Optional body: reason, amount, meta, reference
+     * @return array
+     */
+    public function refund(string $txRef, array $data = []): array
+    {
+        $response = Http::withToken($this->secretKey)->post(
+            $this->baseUrl . '/refund/' . $txRef,
+            $data
+        )->json();
+
+        return $response;
+    }
+    
+    /**
+     * Get your Chapa account balance.
+     *
+     * @param  string|null  $currency Optional currency code 
+     * @return array
+     */
+    public function getBalance(string $currency = null): array
+    {
+        $url = $this->baseUrl . '/balances';
+
+        if ($currency) {
+            $url .= '/' . strtolower($currency);
+        }
+
+        return Http::withToken($this->secretKey)
+            ->get($url)
+            ->json();
+    }
 }


### PR DESCRIPTION
This PR introduces new capabilities to the Chapa Laravel package and fixes the CI workflow to properly run tests for a Laravel package environment.

New Features

refund() – Allows initiating refunds for a given tx_ref, with optional fields such as reason, amount, reference, and meta.

getBalance() – Retrieves the merchant’s account balance, with optional currency filtering.

CI Workflow Fix

Updated GitHub Actions to run on PHP 8.3 for compatibility with PHPUnit 11 and Testbench 9.

Removed Laravel application-specific steps (artisan, .env, storage permissions, SQLite setup) that caused CI failures.

Testbench now runs cleanly with package-appropriate configuration.